### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [work]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v2
+

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ React + Vite version of Conway's Game of Life.
 - Install dependencies: `npm install`
 - Start dev server: `npm run dev`
 - Build for production: `npm run build`
+
+## Deployment
+
+Pushing to the `work` branch will build the project and deploy the contents of `dist/` to GitHub Pages automatically.

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/vibelife/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- configure Vite to serve from /vibelife/ for GitHub Pages
- add GitHub Actions workflow to build and deploy to GitHub Pages when pushing to `work`
- document automatic deployment in the README

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee52d958832dbc9921eb0981427a